### PR TITLE
Fix for collision bug

### DIFF
--- a/Assets/Prefabs/AsteroidBig.prefab
+++ b/Assets/Prefabs/AsteroidBig.prefab
@@ -90,7 +90,7 @@ MeshCollider:
   m_Enabled: 1
   serializedVersion: 2
   m_Convex: 1
-  m_Mesh: {fileID: 4300004, guid: 590dd2f58d285a24a9e5414e845c7ddd, type: 3}
+  m_Mesh: {fileID: 4300000, guid: 768ffef3b9e8d154298721f8cc06e1bf, type: 3}
 --- !u!114 &11406672
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/AsteroidSmall.prefab
+++ b/Assets/Prefabs/AsteroidSmall.prefab
@@ -90,7 +90,7 @@ MeshCollider:
   m_Enabled: 1
   serializedVersion: 2
   m_Convex: 1
-  m_Mesh: {fileID: 4300002, guid: 21fc6ba3d374f1b4e874d55e176b8577, type: 3}
+  m_Mesh: {fileID: 4300000, guid: 768ffef3b9e8d154298721f8cc06e1bf, type: 3}
 --- !u!114 &11406672
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Prefabs/Ship.prefab
+++ b/Assets/Prefabs/Ship.prefab
@@ -179,7 +179,7 @@ MeshCollider:
   m_Enabled: 1
   serializedVersion: 2
   m_Convex: 1
-  m_Mesh: {fileID: 4300000, guid: 23945f3af3eccc84ba1f770397a1d0ad, type: 3}
+  m_Mesh: {fileID: 4300000, guid: e3450e942deff964e80bc00901c56a2f, type: 3}
 --- !u!82 &8262408
 AudioSource:
   m_ObjectHideFlags: 1


### PR DESCRIPTION
Mesh colliders in ship and asteroid prefabs were referencing Blender
meshes which can't be imported if the developer doesn't have
Blender installed. This render physics unresponsive to collisions.

I changed the meshes used by the collider to the FBX variants.