### PR TITLE
Particles no longer smear over screen when crossing edge

### DIFF
--- a/Assets/Prefabs/Ship.prefab
+++ b/Assets/Prefabs/Ship.prefab
@@ -41,6 +41,7 @@ GameObject:
   - 4: {fileID: 483300}
   - 198: {fileID: 19862720}
   - 199: {fileID: 19911248}
+  - 114: {fileID: 11433406}
   m_Layer: 0
   m_Name: Thruster
   m_TagString: Untagged
@@ -262,6 +263,26 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6be9d2b06281f6d4b9b830c1ab0927c2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  beforeWrap:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
+--- !u!114 &11433406
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 144792}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6afa95e58fac6a48be38d16eb0b31fa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  particles: {fileID: 0}
+  storedEmissionValue: 0
+  trigger:
+    scheduledFrame: -1
 --- !u!114 &11484372
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/Scripts/Particles.meta
+++ b/Assets/Scripts/Particles.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: bbc7c2592e7f90d4894e230287d9fe89
+folderAsset: yes
+timeCreated: 1448572280
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Particles/ParticleScreenWrapperBugfix.cs
+++ b/Assets/Scripts/Particles/ParticleScreenWrapperBugfix.cs
@@ -1,0 +1,74 @@
+﻿using UnityEngine;
+
+/// <summary>
+/// <para/> Disables particle emission, until next frame.
+/// <para/> Listens to ScreenWrapper.beforeWrap in parent game object to fix particle wrapping bugs. 
+/// </summary>
+[RequireComponent(typeof(ParticleSystem))]
+sealed class ParticleScreenWrapperBugfix : MonoBehaviour
+{
+    [SerializeField]
+    [HideInInspector]
+    ParticleSystem particles;
+
+    [SerializeField]
+    [HideInInspector]
+    bool storedEmissionValue;
+
+    [SerializeField]
+    [HideInInspector]
+    FrameCountTrigger trigger = FrameCountTrigger.Unscheduled();
+
+    void OnEnable()
+    { 
+        var wrapper = GetComponentInParent<ScreenWrapper>();
+        if (wrapper)
+            wrapper.beforeWrap.AddListener(DisableEmissionUntilNextFrame_Bugfix_Hack);
+
+        particles = GetComponent<ParticleSystem>();
+    }
+
+    void OnDisable()
+    {
+        var wrapper = GetComponentInParent<ScreenWrapper>();
+        if (wrapper)
+            wrapper.beforeWrap.RemoveListener(DisableEmissionUntilNextFrame_Bugfix_Hack);
+
+        if (trigger.TryUnscheduleEarly())
+            RestoreEmission_Bugfix_Hack();
+    }
+
+    void DisableEmissionUntilNextFrame_Bugfix_Hack()
+    {
+        if (!trigger.IsScheduled)
+        {
+            trigger.ScheduleNextFrame();
+            StoreEmission_Bugfix_Hack();
+            particles.enableEmission = false;
+        }
+    }
+
+    void Update()
+    {
+        if (trigger.TryUnschedule())
+            RestoreEmission_Bugfix_Hack();
+    }
+
+    void StoreEmission_Bugfix_Hack()
+    {
+        // This is not super ideal, but I can't think of a good solution;
+        // particles.enableEmission could be changed by another script
+        // later in this frame causing a race condition because there's
+        // no write restriction to enableEmission. Sorry, dear developer!
+        storedEmissionValue = particles.enableEmission;
+    }
+
+    void RestoreEmission_Bugfix_Hack()
+    {
+        // This is not super ideal, but I can't think of a good solution;
+        // particles.enableEmission could be changed by another script
+        // earlier in this frame causing a race condition because there's
+        // no write restriction to enableEmission. Sorry, dear developer!
+        particles.enableEmission = storedEmissionValue;
+    }
+}

--- a/Assets/Scripts/Particles/ParticleScreenWrapperBugfix.cs.meta
+++ b/Assets/Scripts/Particles/ParticleScreenWrapperBugfix.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b6afa95e58fac6a48be38d16eb0b31fa
+timeCreated: 1448572293
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Util.meta
+++ b/Assets/Scripts/Util.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: d9caabdc32a37ed499401009b343d26a
+folderAsset: yes
+timeCreated: 1448574069
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Util/FrameCountTrigger.cs
+++ b/Assets/Scripts/Util/FrameCountTrigger.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using UnityEngine;
+
+[Serializable]
+public class FrameCountTrigger
+{
+    [SerializeField]
+    int scheduledFrame;
+
+    const int UNSCHEDULED_FRAME = -1;
+    
+    FrameCountTrigger() { }
+
+    public static FrameCountTrigger Unscheduled()
+    {
+        var trigger = new FrameCountTrigger();
+        trigger.Unschedule();
+        return trigger;
+    }
+
+    public void Unschedule()
+    {
+        scheduledFrame = UNSCHEDULED_FRAME;
+    }
+
+    public bool IsScheduled
+    {
+        get
+        {
+            return scheduledFrame != UNSCHEDULED_FRAME;
+        }
+    }
+
+    public bool IsTriggerDue
+    {
+        get
+        {
+            return IsScheduled && Time.frameCount >= scheduledFrame;
+        }
+    }
+
+    public void ScheduleThisFrame()
+    {
+        ScheduleAfterCurrentFrame(0);
+    }
+
+    public void ScheduleNextFrame()
+    {
+        ScheduleAfterCurrentFrame(1);
+    }
+
+    public void ScheduleAfterCurrentFrame(int framesAheadInTime)
+    {
+        scheduledFrame = Time.frameCount + framesAheadInTime;
+    }
+
+    /// <summary>
+    /// <para /> Unschedules trigger, if trigger is due. 
+    /// <para /> Return true, if unscheduled.
+    /// </summary>
+    public bool TryUnschedule()
+    {
+        if (IsTriggerDue)
+        {
+            Unschedule();
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// <para /> Unschedules trigger, if trigger was scheduled.
+    /// <para /> TryUnscheduleEarly will unschedule the frame, ignoring current frame.
+    /// <para /> Return true, if unscheduled.
+    /// </summary>
+    public bool TryUnscheduleEarly()
+    {
+        if (IsScheduled)
+        {
+            Unschedule();
+            return true;
+        }
+        return false;
+    }
+}

--- a/Assets/Scripts/Util/FrameCountTrigger.cs.meta
+++ b/Assets/Scripts/Util/FrameCountTrigger.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: b4567082bbf6df447b7ae3bc3180eaf7
+timeCreated: 1448574077
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The problem was that the particle system on the Ship prefab
emit particles when it detects movement. Unfortunately screen
wrapping confuse the particle system into emitting lots of
particles which smeared across the entire screen.

My solution was to put a script on the particle system that
listens for screen wraps and disables emission for one frame.