### PR TITLE
Refactor ship input

### DIFF
--- a/Assets/Scripts/Input.meta
+++ b/Assets/Scripts/Input.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 015f75a60e8acec45855a890cbc6abd3
+folderAsset: yes
+timeCreated: 1448568073
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Input/ShipInput.cs
+++ b/Assets/Scripts/Input/ShipInput.cs
@@ -1,0 +1,20 @@
+﻿using UnityEngine;
+
+public static class ShipInput
+{
+    public static bool IsShooting()
+    {
+        return Input.GetButtonDown("Fire3");
+    }
+
+    public static float GetTurnAxis()
+    {
+        return Input.GetAxis("Horizontal");
+    }
+
+    public static float GetForwardThrust()
+    {
+        float axis = Input.GetAxis("Vertical");
+        return Mathf.Clamp01(axis); // No backpedal
+    }
+}

--- a/Assets/Scripts/Input/ShipInput.cs.meta
+++ b/Assets/Scripts/Input/ShipInput.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: f1fe5a037c5dbce4d9ee600f6fbb456f
+timeCreated: 1448568085
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ShipMovement.cs
+++ b/Assets/Scripts/ShipMovement.cs
@@ -44,8 +44,8 @@ public class ShipMovement : MonoBehaviour
     // Update is called once per frame. It is the main workhorse function for frame updates.
     void Update()
     {
-        m_TurnInputValue = Input.GetAxis("Horizontal");
-        m_MovementInputValue = Input.GetAxis("Vertical");
+        m_TurnInputValue = ShipInput.GetTurnAxis();
+        m_MovementInputValue = ShipInput.GetForwardThrust();
 
         // Freeze z-position (Rigidbody already does this though)
         Vector3 pos = transform.position;
@@ -70,9 +70,6 @@ public class ShipMovement : MonoBehaviour
 
     private void Move()
     {
-        // No backwards movement for you!
-        if(m_MovementInputValue <= 0) return;
-
         // Create a vector in the direction the ship is facing.
         // Magnitude based on the input, speed and the time between frames.
         Vector3 thrustForce = transform.up * m_MovementInputValue * m_Thrust * Time.deltaTime;

--- a/Assets/Scripts/ShipShooter.cs
+++ b/Assets/Scripts/ShipShooter.cs
@@ -53,7 +53,7 @@ public class ShipShooter : MonoBehaviour
     // Update is called once per frame. It is the main workhorse function for frame updates.
     void Update()
     {
-        if(Input.GetButtonDown("Fire3"))
+        if(ShipInput.IsShooting())
         {
             //Rigidbody bulletInstance = Instantiate(m_BulletPrefab, m_BulletSpawnPoint.position, m_BulletSpawnPoint.rotation) as Rigidbody;
             //bulletInstance.velocity = m_BulletVelocity * m_BulletSpawnPoint.up; //(up = y-axis)


### PR DESCRIPTION
User input controlling the ship has been moved to ShipInput.cs
This groups all code related to input in one place which serve a
few benefits:

New project members can easily find all ship input code in a single
location. This makes it easier to understand which buttons to press.

Input specific logic can be placed in ShipInput. For instance,
GetForwardThrust only return values in the range (0, 1).
Ship logic code doesn't have to worry about sanitizing ship input.